### PR TITLE
Removes youtubeadl specific context processor

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -70,9 +70,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-
-                # Local context processors.
-                'youtubeadl.apps.core.context_processors.third_party_tracking_ids',
             ],
             'loaders': [
                 'django.template.loaders.filesystem.Loader',


### PR DESCRIPTION
There was a youtubeadl context processor in settings/base.py 
This commit removes it.
